### PR TITLE
added new KeyExhange class for diffie-hellman-group14-sha256

### DIFF
--- a/ConnectionInfo.cs
+++ b/ConnectionInfo.cs
@@ -325,6 +325,7 @@ namespace Renci.SshNet
                     {"diffie-hellman-group-exchange-sha256", typeof (KeyExchangeDiffieHellmanGroupExchangeSha256)},
                     {"diffie-hellman-group-exchange-sha1", typeof (KeyExchangeDiffieHellmanGroupExchangeSha1)},
                     {"diffie-hellman-group14-sha1", typeof (KeyExchangeDiffieHellmanGroup14Sha1)},
+                    {"diffie-hellman-group14-sha256", typeof (KeyExchangeDiffieHellmanGroup14Sha256)},
                     {"diffie-hellman-group1-sha1", typeof (KeyExchangeDiffieHellmanGroup1Sha1)},
                     //{"ecdh-sha2-nistp256", typeof(KeyExchangeEllipticCurveDiffieHellman)},
                     //{"ecdh-sha2-nistp256", typeof(...)},

--- a/Security/KeyExchangeDiffieHellmanGroup14Sha256.cs
+++ b/Security/KeyExchangeDiffieHellmanGroup14Sha256.cs
@@ -1,0 +1,35 @@
+﻿using Renci.SshNet.Abstractions;
+
+namespace Renci.SshNet.Security
+{
+    internal class KeyExchangeDiffieHellmanGroup14Sha256 : KeyExchangeDiffieHellmanGroup14Sha1
+    {
+        /// <summary>
+        /// Gets algorithm name.
+        /// </summary>
+        public override string Name => "diffie-hellman-group14-sha256";
+
+        /// <summary>
+        /// Gets the size, in bits, of the computed hash code.
+        /// </summary>
+        /// <value>
+        /// The size, in bits, of the computed hash code.
+        /// </value>
+        protected override int HashSize => 256;
+
+        /// <summary>
+        /// Hashes the specified data bytes.
+        /// </summary>
+        /// <param name="hashBytes">Data to hash.</param>
+        /// <returns>
+        /// Hashed bytes
+        /// </returns>
+        protected override byte[] Hash(byte[] hashBytes)
+        {
+            using (var sha256 = CryptoAbstraction.CreateSHA256())
+            {
+                return sha256.ComputeHash(hashBytes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello, I use SSH.NET for accessing a Cisco Firewall and our security want from us to use SHA256. But in KeyExchange algorithm in SSH.NET with SHA256 are not in Cisco than I derive new KeyExchange class with is available in Cisco and add it to SSH.NET. 